### PR TITLE
Add support for property-changed handlers

### DIFF
--- a/Bpz.Test/SourceText/PropertyChangedHandlers.cs
+++ b/Bpz.Test/SourceText/PropertyChangedHandlers.cs
@@ -12,7 +12,7 @@ namespace PropsChanged
 		private static void OnBPropertyChanged(Butt self, DependencyPropertyChangedEventArgs e) { }
 
 		public static readonly DependencyProperty CProperty = Gen.C<int>();
-		private static void CChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) { }
+		private static void CChanged(object d, DependencyPropertyChangedEventArgs e) { }
 
 		public static readonly DependencyProperty DProperty = Gen.D<int>();
 		//private static void OnDChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) { }
@@ -22,6 +22,9 @@ namespace PropsChanged
 
 		public static readonly DependencyProperty FProperty = Gen.F<int>(456);
 		private static void OnFChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) { }
+
+		public static readonly DependencyProperty FProperty = GenAttached<Butt>.Name("None");
+		private static void NamePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) { }
 
 		// void PropertyChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		// object CoerceValueCallback(DependencyObject d, object baseValue)

--- a/Bpz.Test/SourceText/PropertyChangedHandlers.cs
+++ b/Bpz.Test/SourceText/PropertyChangedHandlers.cs
@@ -1,0 +1,36 @@
+using System.Windows;
+using Butt = System.Windows.Controls.Button;
+
+namespace PropsChanged
+{
+	public partial class TestMe : Butt
+	{
+		public static readonly DependencyProperty AProperty = Gen.A<int>();
+		private static void APropertyChanged(TestMe self, DependencyPropertyChangedEventArgs e) { }
+
+		public static readonly DependencyProperty BProperty = Gen.B<int>();
+		private static void OnBPropertyChanged(Butt self, DependencyPropertyChangedEventArgs e) { }
+
+		public static readonly DependencyProperty CProperty = Gen.C<int>();
+		private static void CChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) { }
+
+		public static readonly DependencyProperty DProperty = Gen.D<int>();
+		//private static void OnDChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) { }
+
+		public static readonly DependencyProperty EProperty = Gen.E<int>(123);
+		//private static void OnEChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) { }
+
+		public static readonly DependencyProperty FProperty = Gen.F<int>(456);
+		private static void OnFChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) { }
+
+		// void PropertyChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		// object CoerceValueCallback(DependencyObject d, object baseValue)
+		// private static object OnCoerceClip(DependencyObject d, object baseValue)
+
+		// OnNamePropertyChanged
+		//   NamePropertyChanged
+		// OnName        Changed
+
+		// DependencyObject, OwnerType
+	}
+}

--- a/boilerplatezero/Wpf/DependencyPropertyGenerator.cs
+++ b/boilerplatezero/Wpf/DependencyPropertyGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -48,7 +49,7 @@ namespace Bpz.Wpf
 
 					foreach (var generateThis in classGroup)
 					{
-						ApppendSource(context, sourceBuilder, generateThis);
+						this.ApppendSource(context, sourceBuilder, generateThis);
 					}
 
 					sourceBuilder.AppendLine("\t}");
@@ -159,9 +160,10 @@ using System.Windows;
 					{
 						var model = context.Compilation.GetSemanticModel(typeArgNode.SyntaxTree);
 						var typeInfo = model.GetTypeInfo(typeArgNode, context.CancellationToken);
-						targetTypeName = typeInfo.Type?.ToDisplayString();
-						if (targetTypeName != null)
+						if (typeInfo.Type != null)
 						{
+							generateThis.AttachmentNarrowingType = typeInfo.Type;
+							targetTypeName = typeInfo.Type.ToDisplayString();
 							moreDox = $@"<br/>This attached property is only for use with objects of type <see cref=""{targetTypeName}""/>";
 						}
 					}
@@ -232,23 +234,106 @@ $@"		private static partial class {genClassDecl} {{
 			/// </summary>
 			public static {returnType} {propertyName}<__T>({parameter}) {{");
 
-			if (hasDefaultValue)
-			{
-				sourceBuilder.AppendLine("PropertyMetadata typeMetadata = new PropertyMetadata(defaultValue);");
-			}
-			else
-			{
-				string nullLiteral = this.useNullableContext ? "null!" : "null";
-				sourceBuilder.AppendLine($"PropertyMetadata typeMetadata = {nullLiteral};");
-			}
+			this.ApppendPropertyMetadata(context, sourceBuilder, generateThis, hasDefaultValue);
 
 			string a = generateThis.IsAttached ? "Attached" : "";
 			string ro = generateThis.IsDpk ? "ReadOnly" : "";
 			string ownerTypeName = GetTypeName(generateThis.FieldSymbol.ContainingType);
 			sourceBuilder.AppendLine(
-$@"return DependencyProperty.Register{a}{ro}(""{propertyName}"", typeof(__T), typeof({ownerTypeName}), typeMetadata);
+$@"return DependencyProperty.Register{a}{ro}(""{propertyName}"", typeof(__T), typeof({ownerTypeName}), metadata);
 			}}
 		}}");
+		}
+
+		/// <summary>
+		/// Appends source text that declares the property metadata variable named "metadata".
+		/// Accounts for whether a default value exists.
+		/// Accounts for whether a compatible property-changed handler exists.
+		/// </summary>
+		private void ApppendPropertyMetadata(GeneratorExecutionContext context, StringBuilder sourceBuilder, GenerationDetails generateThis, bool hasDefaultValue)
+		{
+			INamedTypeSymbol ownerType = generateThis.FieldSymbol.ContainingType;
+			string propertyName = generateThis.MethodNameNode.Identifier.ValueText;
+
+			// Looking for methods like...
+			//  FooPropertyChanged
+			//  OnFooChanged
+			var changeHandlerSymbol = (IMethodSymbol?)ownerType.GetMembers().FirstOrDefault(s =>
+				s.Kind == SymbolKind.Method &&
+				s.Name.EndsWith("Changed", StringComparison.Ordinal) &&
+				s.Name.IndexOf(propertyName, 0, s.Name.Length - "Changed".Length, StringComparison.Ordinal) >= 0
+			);
+
+			// See if we have a property-changed handler.
+			// For now, only accept methods like...
+			//  static void FooPropertyChanged(Widget self, DependencyPropertyChangedEventArgs e) { ... }
+			string? changeHandler = null;
+			if (changeHandlerSymbol?.Parameters.Length == 2 &&
+				changeHandlerSymbol.IsStatic &&
+				changeHandlerSymbol.ReturnType.SpecialType == SpecialType.System_Void)
+			{
+				INamedTypeSymbol doTypeSymbol = context.Compilation.GetTypeByMetadataName("System.Windows.DependencyObject")!;
+				INamedTypeSymbol argsTypeSymbol = context.Compilation.GetTypeByMetadataName("System.Windows.DependencyPropertyChangedEventArgs")!;
+
+				ITypeSymbol p0TypeSymbol = changeHandlerSymbol.Parameters[0].Type;
+				ITypeSymbol p1TypeSymbol = changeHandlerSymbol.Parameters[1].Type;
+
+				if (p1TypeSymbol.Equals(argsTypeSymbol, SymbolEqualityComparer.Default))
+				{
+					if (p0TypeSymbol.Equals(doTypeSymbol, SymbolEqualityComparer.Default))
+					{
+						// Signature matches `System.Windows.PropertyChangedCallback`, so we can just use the method name.
+						changeHandler = changeHandlerSymbol.Name;
+					}
+					else
+					{
+						// Need to ensure type of p0 is valid.
+						ITypeSymbol derivedTypeSymbol;
+						if (generateThis.IsAttached)
+						{
+							// Narrowing type must be equal to, or derived from, the p0 type.
+							derivedTypeSymbol = generateThis.AttachmentNarrowingType ?? doTypeSymbol;
+						}
+						else
+						{
+							// Owner type must be equal to, or derived from, the p0 type.
+							derivedTypeSymbol = ownerType;
+						}
+
+						if (CanCastTo(derivedTypeSymbol, p0TypeSymbol))
+						{
+							// Something like...
+							//  (d, e) => FooPropertyChanged((Goodies.Widget)d, e)
+							changeHandler = $"(d, e) => {changeHandlerSymbol.Name}(({p0TypeSymbol.ToDisplayString()})d, e)";
+						}
+					}
+				}
+			}
+
+			if (hasDefaultValue)
+			{
+				if (changeHandler != null)
+				{
+					// Has default value & callback.
+					sourceBuilder.AppendLine($"PropertyMetadata metadata = new PropertyMetadata(defaultValue, {changeHandler});");
+					return;
+				}
+
+				// Has default value.
+				sourceBuilder.AppendLine("PropertyMetadata metadata = new PropertyMetadata(defaultValue);");
+				return;
+			}
+
+			if (changeHandler != null)
+			{
+				// Has callback.
+				sourceBuilder.AppendLine($"PropertyMetadata metadata = new PropertyMetadata({changeHandler});");
+				return;
+			}
+
+			// No default value & no callback.
+			string nullLiteral = this.useNullableContext ? "null!" : "null";
+			sourceBuilder.AppendLine($"PropertyMetadata metadata = {nullLiteral};");
 		}
 
 		private static IEnumerable<GenerationDetails> UpdateAndFilterGenerationRequests(GeneratorExecutionContext context, IEnumerable<GenerationDetails> requests)
@@ -314,6 +399,22 @@ $@"return DependencyProperty.Register{a}{ro}(""{propertyName}"", typeof(__T), ty
 			return typeSymbol.Name;
 		}
 
+		private static bool CanCastTo(ITypeSymbol checkMe, ITypeSymbol baseTypeSymbol)
+		{
+			do
+			{
+				if (checkMe.Equals(baseTypeSymbol, SymbolEqualityComparer.Default))
+				{
+					return true;
+				}
+
+				checkMe = checkMe.BaseType!;
+			}
+			while (checkMe != null);
+
+			return false;
+		}
+
 		private class SyntaxReceiver : ISyntaxReceiver
 		{
 			public List<GenerationDetails> GenerationRequests { get; } = new();
@@ -361,11 +462,12 @@ $@"return DependencyProperty.Register{a}{ro}(""{propertyName}"", typeof(__T), ty
 			public IFieldSymbol FieldSymbol { get; set; } = null!;
 			public bool IsDpk { get; set; }
 			public bool IsAttached { get; }
+			public ITypeSymbol? AttachmentNarrowingType { get; set; }
 		}
 
 		private static class Diagnostics
 		{
-			private static readonly DiagnosticDescriptor MismatchedIdentifiersDescriptor = new DiagnosticDescriptor(
+			private static readonly DiagnosticDescriptor MismatchedIdentifiersError = new DiagnosticDescriptor(
 				"BPZ0001",
 				"Mismatched identifiers",
 				"Field name '{0}' and method name '{1}' do not match. Expected '{2} = {3}'.",
@@ -379,7 +481,7 @@ $@"return DependencyProperty.Register{a}{ro}(""{propertyName}"", typeof(__T), ty
 			public static Diagnostic MismatchedIdentifiers(IFieldSymbol fieldSymbol, string methodName, string expectedFieldName, string initializer)
 			{
 				return Diagnostic.Create(
-					MismatchedIdentifiersDescriptor,
+					MismatchedIdentifiersError,
 					fieldSymbol.Locations[0],
 					fieldSymbol.Name,
 					methodName,
@@ -387,7 +489,7 @@ $@"return DependencyProperty.Register{a}{ro}(""{propertyName}"", typeof(__T), ty
 					initializer);
 			}
 
-			private static readonly DiagnosticDescriptor UnexpectedFieldTypeDescriptor = new DiagnosticDescriptor(
+			private static readonly DiagnosticDescriptor UnexpectedFieldTypeError = new DiagnosticDescriptor(
 				"BPZ1001",
 				"Unexpected field type",
 				"'{0}.{1}' has unexpected type '{2}'. Expected 'System.Windows.DependencyProperty' or 'System.Windows.DependencyPropertyKey'.",
@@ -401,7 +503,7 @@ $@"return DependencyProperty.Register{a}{ro}(""{propertyName}"", typeof(__T), ty
 			public static Diagnostic UnexpectedFieldType(IFieldSymbol fieldSymbol)
 			{
 				return Diagnostic.Create(
-					UnexpectedFieldTypeDescriptor,
+					UnexpectedFieldTypeError,
 					fieldSymbol.Locations[0],
 					fieldSymbol.ContainingType.Name,
 					fieldSymbol.Name,


### PR DESCRIPTION
- Now supports property-changed handlers by looking for methods like
   ```csharp
   static void FooPropertyChanged(Widget self, DependencyPropertyChangedEventArgs e) { ... }
   ```
   These are static methods named like `*Name*Changed` with compatible parameter types.
- Fix for bug in `GetTypeName` if generic parameters had dots (ex: `Widget<System.Int32>` would get `Int32>`)
- Changed generic type name for good measure (`TTarget` to `__TTarget`)