### PR TITLE
improved formatting of generated code

### DIFF
--- a/Bpz.Test/Widget.cs
+++ b/Bpz.Test/Widget.cs
@@ -11,6 +11,9 @@ namespace Bpz.Test
 		public static readonly DependencyProperty MyBool1Property = Gen.MyBool1<bool>();
 		public static readonly DependencyProperty MyBool2Property = Gen.MyBool2((bool?)false);
 
+		/// <summary>
+		/// Test dox! Gets or sets a string value or something.
+		/// </summary>
 		public static readonly DependencyProperty MyString0Property = Gen.MyString0("asdf");
 		public static readonly DependencyProperty MyString1Property = Gen.MyString1<string?>();
 		public static readonly DependencyProperty MyString2Property = Gen.MyString2(default(string?));

--- a/boilerplatezero/GlobalSuppressions.cs
+++ b/boilerplatezero/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "IDE0057:Use range operator", Justification = "not supported in .net standard 2.0")]

--- a/boilerplatezero/boilerplatezero.csproj
+++ b/boilerplatezero/boilerplatezero.csproj
@@ -11,7 +11,7 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <PackageId>boilerplatezero</PackageId>
-    <Version>1.5.1</Version>
+    <Version>1.5.2</Version>
     <Authors>IGood</Authors>
     <Company />
     <Copyright>Copyright (c) Ian Good</Copyright>


### PR DESCRIPTION
saw this style [here](https://github.com/maryamariyan/runtime/blob/2814f8912c05019c1d1b161e0201eda3f7fc8e69/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Emitter.cs) & thought it was good

makes things nicer with more line breaks & uses `Append` instead of `AppendLine`, which has better performance