### PR TITLE
updated generated documentation

### DIFF
--- a/Bpz.Test/Bpz.Test.csproj
+++ b/Bpz.Test/Bpz.Test.csproj
@@ -6,6 +6,7 @@
     <UseWPF>true</UseWPF>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Bpz.Test/MyService.cs
+++ b/Bpz.Test/MyService.cs
@@ -1,5 +1,6 @@
 // Copyright © Ian Good
 
+using System.Collections.Generic;
 using System.Windows;
 
 namespace Bpz.Test
@@ -10,7 +11,13 @@ namespace Bpz.Test
 
 		public static readonly RoutedEvent FooChangedEvent = GenAttached.FooChanged<RoutedPropertyChangedEventHandler<int>>(RoutingStrategy.Bubble);
 
-		public static readonly RoutedEvent BarChangedEvent = GenAttached.BarChanged<int>();
+		public static readonly RoutedEvent BarChangedEvent = GenAttached.BarChanged<List<float>>();
+
+		public static readonly RoutedEvent InspectedEvent = GenAttached<System.Windows.Controls.Canvas>.Inspected();
+
+		public static readonly RoutedEvent SomeToolTipEvent = GenAttached.SomeToolTip<System.Windows.Controls.ToolTipEventHandler>();
+
+		public static readonly RoutedEvent DataTransferEvent = GenAttached.DataTransfer<System.EventHandler<System.Windows.Data.DataTransferEventArgs>>();
 
 		private static readonly RoutedEvent SomethingPrivateHappenedEvent = GenAttached.SomethingPrivateHappened();
 	}

--- a/Bpz.Test/MyServiceTests.cs
+++ b/Bpz.Test/MyServiceTests.cs
@@ -42,7 +42,30 @@ namespace Bpz.Test
 				{
 					OwnerType = typeof(MyService),
 					Name = "BarChanged",
-					HandlerType = typeof(RoutedPropertyChangedEventHandler<int>),
+					HandlerType = typeof(RoutedPropertyChangedEventHandler<List<float>>),
+					IsAttached = true,
+				};
+
+				yield return new()
+				{
+					OwnerType = typeof(MyService),
+					Name = "Inspected",
+					AttachmentNarrowingType = typeof(System.Windows.Controls.Canvas),
+				};
+
+				yield return new()
+				{
+					OwnerType = typeof(MyService),
+					Name = "SomeToolTip",
+					HandlerType = typeof(System.Windows.Controls.ToolTipEventHandler),
+					IsAttached = true,
+				};
+
+				yield return new()
+				{
+					OwnerType = typeof(MyService),
+					Name = "DataTransfer",
+					HandlerType = typeof(System.EventHandler<System.Windows.Data.DataTransferEventArgs>),
 					IsAttached = true,
 				};
 

--- a/Bpz.Test/Widget.cs
+++ b/Bpz.Test/Widget.cs
@@ -1,6 +1,7 @@
 // Copyright © Ian Good
 
 using System;
+using System.Collections.Generic;
 using System.Windows;
 
 namespace Bpz.Test
@@ -18,6 +19,8 @@ namespace Bpz.Test
 		public static readonly DependencyProperty MyString1Property = Gen.MyString1<string?>();
 		public static readonly DependencyProperty MyString2Property = Gen.MyString2(default(string?));
 		public static readonly DependencyProperty MyString3Property = Gen.MyString3("qwer");
+
+		public static readonly DependencyProperty MyDictionaryProperty = Gen.MyDictionary<Dictionary<int, List<string>>?>();
 
 		private static void MyString0PropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		{

--- a/Bpz.Test/WidgetTests.cs
+++ b/Bpz.Test/WidgetTests.cs
@@ -80,6 +80,14 @@ namespace Bpz.Test
 				yield return new()
 				{
 					OwnerType = typeof(Widget),
+					Name = "MyDictionary",
+					PropertyType = typeof(Dictionary<int, List<string>>),
+					DefaultValue = null,
+				};
+
+				yield return new()
+				{
+					OwnerType = typeof(Widget),
 					Name = "MyFloat0",
 					PropertyType = typeof(float),
 					DefaultValue = 3.14f,

--- a/boilerplatezero/Wpf/DependencyPropertyGenerator.cs
+++ b/boilerplatezero/Wpf/DependencyPropertyGenerator.cs
@@ -209,7 +209,7 @@ using System.Windows;
 					{
 						generateThis.AttachmentNarrowingType = attachmentNarrowingType;
 						targetTypeName = attachmentNarrowingType.ToDisplayString();
-						moreDox = $@"<br/>This attached property is only for use with objects of type <see cref=""{GeneratorOps.ReplaceBrackets(targetTypeName)}""/>.";
+						moreDox = $@"<br/>This attached property is only for use with objects of type <typeparamref name=""__TTarget""/>.";
 					}
 				}
 				else
@@ -291,7 +291,7 @@ using System.Windows;
 		private static partial class {genClassDecl}
 		{{
 			/// <summary>
-			/// Registers {what} named ""{propertyName}"" whose type is <see cref=""{GeneratorOps.ReplaceBrackets(generateThis.PropertyTypeName)}""/>.{moreDox}
+			/// Registers {what} named ""{propertyName}"" whose type is <typeparamref name=""__T""/>.{moreDox}
 			/// </summary>
 			public static {returnType} {propertyName}<__T>({parameters})
 			{{

--- a/boilerplatezero/boilerplatezero.csproj
+++ b/boilerplatezero/boilerplatezero.csproj
@@ -11,7 +11,7 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <PackageId>boilerplatezero</PackageId>
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
     <Authors>IGood</Authors>
     <Company />
     <Copyright>Copyright (c) Ian Good</Copyright>
@@ -25,7 +25,7 @@ Included generators:
     <PackageProjectUrl>https://github.com/IGood/boilerplatezero</PackageProjectUrl>
     <RepositoryUrl>https://github.com/IGood/boilerplatezero.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>bpz,source generator,wpf,dependency properties, routed events</PackageTags>
+    <PackageTags>bpz,source generator,wpf,dependency properties,routed events</PackageTags>
     <PackageIcon>bpz logo dark.png</PackageIcon>
   </PropertyGroup>
 


### PR DESCRIPTION
This fixes #15 where type names of constructed generic types were causing warnings when documentation files are generated for a project